### PR TITLE
feat: Add GitHub Actions workflow for deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,31 @@
+name: Deploy
+
+on:
+  pull_request:
+    branches: [ 'main' ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build
+        uses: withastro/action@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,6 @@ import sitemap from '@astrojs/sitemap';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://CityBear3.github.io',
+	site: 'https://citybear3.github.io',
 	integrations: [mdx(), sitemap()],
 });


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automate deployment for the main branch using Astro and GitHub Pages. Additionally, it corrects the casing in the `site` URL within `astro.config.mjs` for consistency. These changes streamline the deployment process and ensure proper configuration.