### PR TITLE
Switch deployment trigger from pull_request to push

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,8 +1,9 @@
 name: Deploy
 
 on:
-  pull_request:
-    branches: [ 'main' ]
+  push:
+    branches:
+      - "main"
 
 permissions:
   contents: read


### PR DESCRIPTION
Changed the workflow to trigger on push events to the "main" branch instead of pull requests. This ensures deployments are aligned with direct updates to the main branch.